### PR TITLE
Fix NSRangeException error on empty array when relation does not exist

### DIFF
--- a/Classes/MTLHALResource.m
+++ b/Classes/MTLHALResource.m
@@ -177,7 +177,11 @@ static NSMutableDictionary *p_classesForRelations;
 }
 
 - (MTLHALResource *)resourceForRelation:(NSString *)relation {
-    return [self resourcesForRelation:relation][0];
+
+    if (self.embedded[relation] == [NSNull null])
+        return nil;
+    else
+        return [self resourcesForRelation:relation][0];
 }
 
 + (void)registerClass:(__unsafe_unretained Class)targetClass forRelation:(NSString *)relation


### PR DESCRIPTION
I've fixed the case where a relation that did not exist caused an NSRangeException on an empty array, which was resulting in our app crashing.
